### PR TITLE
Fixes to make Mhook_Unhook() work.

### DIFF
--- a/mhook-lib/mhook.cpp
+++ b/mhook-lib/mhook.cpp
@@ -183,7 +183,9 @@ static VOID ListRemove(MHOOKS_TRAMPOLINE** pListHead, MHOOKS_TRAMPOLINE* pNode) 
 
 	if ((*pListHead) == pNode) {
 		(*pListHead) = pNode->pNextTrampoline;
-		assert((*pListHead)->pPrevTrampoline == NULL);
+		if (*pListHead != NULL) {
+			assert((*pListHead)->pPrevTrampoline == NULL);
+		}
 	}
 
 	pNode->pPrevTrampoline = NULL;
@@ -441,7 +443,7 @@ static MHOOKS_TRAMPOLINE* TrampolineGet(PBYTE pHookedFunction) {
 	MHOOKS_TRAMPOLINE* pCurrent = g_pHooks;
 
 	while (pCurrent) {
-		if (pCurrent->pHookFunction == pHookedFunction) {
+		if ((PBYTE)&(pCurrent->codeTrampoline) == pHookedFunction) {
 			return pCurrent;
 		}
 


### PR DESCRIPTION
This fixes ListRemove() when deleting the last trampoline in a
list, and fixes TrampolineGet() so it can find trampolines.
Issue martona#2 should be fixed by these changes.
